### PR TITLE
Fixing formatting in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ After this is installed, you can import the provided dashboards that will provid
 1. Login to Kibana
 2. Navigate to Dev Tools located under the Management section
 3. Add the below request + JSON into the left pane where the complete JSON is the contents of the [index_templates/cyral_data_activity_log.json](index_templates/cyral_data_activity_log.json)
-   ```PUT _index_template/cyral_index_template
+```
+PUT _index_template/cyral_index_template
 {
   "index_patterns": [
     "filebeat-*",
@@ -26,6 +27,7 @@ After this is installed, you can import the provided dashboards that will provid
     "description": "Cyral Index Template Pattern for creating elasticsearch indices"
   },
   ...
+```
 4. click the Click to send request button (it looks like a play button at the top right corner of the pane)
 
 ### Additional Steps (Optional)
@@ -34,7 +36,8 @@ If this is a new ELK instance already has some `cyral-data-activity-log*` indexe
 
 1. You’ll need to reindex each old index so that it will be built using the provided template using the Dev Tools request similar to the below. This command should tell ELK to copy the cyral-data-activity-logs-2023.05.05 into cyral-data-activity-logs-2023.05.05-new and reindex it. As this matches our pattern above for the template, cyral-data-activity-logs*, it should be correctly indexed into the format that our dashboards and scripted fields expect.
    - This does not accept wildcards so it’ll need to be repeated for each index that exists.
-  ```POST _reindex
+```
+POST _reindex
 {
   "source": {
     "index": "cyral-data-activity-logs-2023.05.05"
@@ -43,9 +46,11 @@ If this is a new ELK instance already has some `cyral-data-activity-log*` indexe
     "index": "cyral-data-activity-logs-2023.05.05-new"
   }
 }
+```
 2. Once an index has been reindexed, you’ll want to delete the old index so that you no longer receive any errors. You can issue the below Dev Tools request for each index to delete it
-  ```DELETE cyral-data-activity-logs-2023.05.05
-
+```
+DELETE cyral-data-activity-logs-2023.05.05
+```
 ## Example Dashboards
 
 1. Login to Kibana


### PR DESCRIPTION
There were formatting issues in the README.md file causing the example commands to be hidden when rendered in markdown.

This change fixes the those code blocks.